### PR TITLE
Add -y to apt-get install

### DIFF
--- a/install_docker.sh
+++ b/install_docker.sh
@@ -32,7 +32,7 @@ apt-get install \
     apt-transport-https \
     ca-certificates \
     curl \
-    software-properties-common
+    software-properties-common -y
 
 # Add Docker GPG Key
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -


### PR DESCRIPTION
prompted for a Y when installing:

apt-transport-https \
    ca-certificates \
    curl \
    software-properties-common 

so just adding a -y to the end of this command to use with PowerUP install.

Signed-off-by: Mick Tarsel <mtarsel@gmail.com>